### PR TITLE
fix: choose gain_transient for starting call

### DIFF
--- a/lib/src/track/audio_management.dart
+++ b/lib/src/track/audio_management.dart
@@ -23,15 +23,10 @@ import '../support/platform.dart';
 import 'local/local.dart';
 import 'remote/remote.dart';
 
-enum AudioTrackState {
-  none,
-  remoteOnly,
-  localOnly,
-  localAndRemote,
-}
+enum AudioTrackState { none, remoteOnly, localOnly, localAndRemote }
 
-typedef ConfigureNativeAudioFunc = Future<NativeAudioConfiguration> Function(
-    AudioTrackState state);
+typedef ConfigureNativeAudioFunc =
+    Future<NativeAudioConfiguration> Function(AudioTrackState state);
 
 // it's possible to set custom function here to customize audio session configuration
 ConfigureNativeAudioFunc onConfigureNativeAudio =
@@ -101,8 +96,10 @@ mixin RemoteAudioManagementMixin on RemoteTrack, AudioTrack {
 }
 
 Future<void> _onAudioTrackCountDidChange() async {
-  logger.fine('onAudioTrackCountDidChange: '
-      'local: $_localTrackCount, remote: $_remoteTrackCount');
+  logger.fine(
+    'onAudioTrackCountDidChange: '
+    'local: $_localTrackCount, remote: $_remoteTrackCount',
+  );
 
   final newState = _computeAudioTrackState();
 
@@ -151,7 +148,8 @@ AudioTrackState _computeAudioTrackState() {
 }
 
 Future<NativeAudioConfiguration> defaultNativeAudioConfigurationFunc(
-    AudioTrackState state) async {
+  AudioTrackState state,
+) async {
   if (state == AudioTrackState.none) {
     return NativeAudioConfiguration.soloAmbient;
   } else if (state == AudioTrackState.remoteOnly &&
@@ -170,10 +168,21 @@ class NativeAudioManagement {
     if (lkPlatformIs(PlatformType.android)) {
       if (Native.bypassVoiceProcessing) {
         await rtc.Helper.setAndroidAudioConfiguration(
-            rtc.AndroidAudioConfiguration.media);
+          rtc.AndroidAudioConfiguration.media,
+        );
       } else {
-        await rtc.Helper.setAndroidAudioConfiguration(
-            rtc.AndroidAudioConfiguration.communication);
+        final rtc.AndroidAudioConfiguration androidAudioConfig =
+            rtc.AndroidAudioConfiguration(
+              manageAudioFocus: true,
+              androidAudioMode: rtc.AndroidAudioMode.inCommunication,
+              androidAudioFocusMode: rtc.AndroidAudioFocusMode.gainTransient,
+              androidAudioStreamType: rtc.AndroidAudioStreamType.voiceCall,
+              androidAudioAttributesUsageType:
+                  rtc.AndroidAudioAttributesUsageType.voiceCommunication,
+              androidAudioAttributesContentType:
+                  rtc.AndroidAudioAttributesContentType.speech,
+            );
+        await rtc.Helper.setAndroidAudioConfiguration(androidAudioConfig);
       }
     }
   }


### PR DESCRIPTION
## What happened?
From now, Livekit chooses focus mode when `AUDIOFOCUS_GAIN` which makes app fully focus and does not give focus back to any previous media apps.

This PR overrides default android configuration when call of Livekit. I choose `AUDIOFOCUS_GAIN_TRANSIENT`, this mode is described `temporary gain or request of audio focus`, and of course can give focus to previous media apps (like Youtube can resume).

## Insights
You can find definitions of focus mode here: https://developer.android.com/reference/android/media/AudioManager#AUDIOFOCUS_GAIN

About mechanism of focus on Android here: https://developer.android.com/media/optimize/audio-focus


## Proof of work
I tested with Android phone and it can focus back to Youtube app.